### PR TITLE
Added JSDoc documentation

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,7 +10,23 @@ const Hoek = require('hoek');
 
 const internals = {};
 
-
+/**
+ * Parses the range from a HTTP header
+ *
+ * @name header
+ * @static
+ * @method
+ * @param {string} header - a string in the form of `bytes=from-to`, where
+ * `from` and `to` are integers specifying the range. Both are optional.
+ * Multiple ranges can be passed as a comma delimited list.
+ * @param {number} length - the maximum length the range cover. If a `to` value
+ * passed in the `header` string is greater than `length`, the `to` value is set
+ * as `length - 1`.
+ * @returns {?Array.<Object>} - returns an array of objects with the properties
+ * `from` and `to`, which specify the beginning and ending of the range(s).
+ * Overlapping ranges are combined into one object. Returns `null` for invalid
+ * input.
+ */
 exports.header = function (header, length) {
 
     // Parse header
@@ -89,7 +105,17 @@ exports.header = function (header, length) {
     return consolidated;
 };
 
-
+/**
+ * Creates a [`Transform Stream`](https://nodejs.org/api/stream.html#stream_class_stream_transform)
+ * that extracts the portion of a piped in stream within range.
+ *
+ * @name Stream
+ * @param {Object} range - an object with the properties `from` and `to` that
+ * specify the range of piped in stream to read. Objects returned by
+ * `Ammo.header` can be passed into `range`.
+ * @returns {Object} - returns a `Stream` object that extracts the portion of a
+ * piped in stream within the passed range.
+ */
 exports.Stream = internals.Stream = function (range) {
 
     Stream.Transform.call(this);


### PR DESCRIPTION
Adds JSDoc documentation to `lib/index.js`. It's just meant to give a brief outline of the functions in the file to anyone working on it.