### PR TITLE
Added pre-commit hooks to ensure test coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "lab": "11.x.x",
     "wreck": "10.x.x"
   },
+  "pre-commit": "test",
   "scripts": {
     "test": "lab -a code -t 100 -L",
     "test-cov-html": "lab -a code -r html -o coverage.html"


### PR DESCRIPTION
100% is a requirement on the test coverage. With this small PR we ensure that people will always commit running tests before (it can be bypassed but... still... better than nothing).