### PR TITLE
Improve error handling

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,8 +4,6 @@
 
 const Stream = require('stream');
 
-const Hoek = require('hoek');
-
 
 // Declare internals
 
@@ -36,36 +34,37 @@ exports.header = function (header, length) {
             return null;
         }
 
-        const set = {};
+        let from;
+        let to;
         range = range.split('-');
         if (range[0]) {
-            set.from = parseInt(range[0], 10);
+            from = parseInt(range[0], 10);
         }
 
         if (range[1]) {
-            set.to = parseInt(range[1], 10);
-            if (set.from !== undefined) {      // Can be 0
+            to = parseInt(range[1], 10);
+            if (from !== undefined) {      // Can be 0
                 // From-To
-                if (set.to > lastPos) {
-                    set.to = lastPos;
+                if (to > lastPos) {
+                    to = lastPos;
                 }
             }
             else {
                 // -To
-                set.from = length - set.to;
-                set.to = lastPos;
+                from = length - to;
+                to = lastPos;
             }
         }
         else {
             // From-
-            set.to = lastPos;
+            to = lastPos;
         }
 
-        if (set.from > set.to) {
+        if (from > to) {
             return null;
         }
 
-        result.push(set);
+        result.push({ from, to });
     }
 
     if (result.length === 1) {
@@ -94,35 +93,35 @@ exports.header = function (header, length) {
 };
 
 
-exports.Stream = internals.Stream = function (range) {
+exports.Stream = internals.Stream = class extends Stream.Transform {
 
-    Stream.Transform.call(this);
+    constructor(range) {
 
-    this._range = range;
-    this._next = 0;
-};
+        super();
 
-Hoek.inherits(internals.Stream, Stream.Transform);
-
-
-internals.Stream.prototype._transform = function (chunk, encoding, done) {
-
-    // Read desired range from a stream
-
-    const pos = this._next;
-    this._next = this._next + chunk.length;
-
-    if (this._next <= this._range.from ||       // Before range
-        pos > this._range.to) {                 // After range
-
-        return done();
+        this._range = range;
+        this._next = 0;
     }
 
-    // Calc bounds of chunk to read
+    _transform(chunk, encoding, done) {
 
-    const from = Math.max(0, this._range.from - pos);
-    const to = Math.min(chunk.length, this._range.to - pos + 1);
+        // Read desired range from a stream
 
-    this.push(chunk.slice(from, to));
-    return done();
+        const pos = this._next;
+        this._next = this._next + chunk.length;
+
+        if (this._next <= this._range.from ||       // Before range
+            pos > this._range.to) {                 // After range
+
+            return done();
+        }
+
+        // Calc bounds of chunk to read
+
+        const from = Math.max(0, this._range.from - pos);
+        const to = Math.min(chunk.length, this._range.to - pos + 1);
+
+        this.push(chunk.slice(from, to));
+        return done();
+    }
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,10 +4,22 @@
 
 const Stream = require('stream');
 
+const Hoek = require('hoek');
+
 
 // Declare internals
 
 const internals = {};
+
+
+internals.Range = class {
+
+    constructor(from, to) {
+
+        this.from = from;
+        this.to = to;
+    }
+};
 
 
 exports.header = function (header, length) {
@@ -64,7 +76,7 @@ exports.header = function (header, length) {
             return null;
         }
 
-        result.push({ from, to });
+        result.push(new internals.Range(from, to));
     }
 
     if (result.length === 1) {
@@ -96,6 +108,22 @@ exports.header = function (header, length) {
 exports.Stream = internals.Stream = class extends Stream.Transform {
 
     constructor(range) {
+
+        if (!(range instanceof internals.Range)) {
+            Hoek.assert(typeof range === 'object', 'Expected "range" object');
+
+            const from = range.from || 0;
+            Hoek.assert(typeof from === 'number', '"range.from" must be falsy, or a number');
+            Hoek.assert(from === parseInt(from, 10) && from >= 0, '"range.from" must be a positive integer');
+
+            const to = range.to || 0;
+            Hoek.assert(typeof to === 'number', '"range.to" must be falsy, or a number');
+            Hoek.assert(to === parseInt(to, 10) && to >= 0, '"range.to" must be a positive integer');
+
+            Hoek.assert(to >= from, '"range.to" must be greater than or equal to "range.from"');
+
+            range = new internals.Range(from, to);
+        }
 
         super();
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -103,7 +103,7 @@ exports.Stream = internals.Stream = class extends Stream.Transform {
         this._next = 0;
     }
 
-    _transform(chunk, encoding, done) {
+    processChunk(chunk) {
 
         // Read desired range from a stream
 
@@ -113,7 +113,7 @@ exports.Stream = internals.Stream = class extends Stream.Transform {
         if (this._next <= this._range.from ||       // Before range
             pos > this._range.to) {                 // After range
 
-            return done();
+            return;
         }
 
         // Calc bounds of chunk to read
@@ -122,6 +122,17 @@ exports.Stream = internals.Stream = class extends Stream.Transform {
         const to = Math.min(chunk.length, this._range.to - pos + 1);
 
         this.push(chunk.slice(from, to));
+    }
+
+    _transform(chunk, encoding, done) {
+
+        try {
+            this.processChunk(chunk);
+        }
+        catch (err) {
+            return done(err);
+        }
+
         return done();
     }
 };

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
   "engines": {
     "node": ">=8.9.0"
   },
-  "dependencies": {},
+  "dependencies": {
+    "hoek": "5.x.x"
+  },
   "devDependencies": {
     "code": "5.x.x",
     "lab": "15.x.x",

--- a/package.json
+++ b/package.json
@@ -12,9 +12,7 @@
   "engines": {
     "node": ">=8.9.0"
   },
-  "dependencies": {
-    "hoek": "5.x.x"
-  },
+  "dependencies": {},
   "devDependencies": {
     "code": "5.x.x",
     "lab": "15.x.x",

--- a/test/index.js
+++ b/test/index.js
@@ -6,7 +6,6 @@ const Stream = require('stream');
 
 const Ammo = require('..');
 const Code = require('code');
-const Hoek = require('hoek');
 const Lab = require('lab');
 const Wreck = require('wreck');
 
@@ -95,28 +94,29 @@ describe('Stream', () => {
 
     it('processes multiple chunks', async () => {
 
-        const TestStream = function () {
+        const TestStream = class extends Stream.Readable {
 
-            Stream.Readable.call(this);
-            this._count = -1;
-        };
+            constructor() {
 
-        Hoek.inherits(TestStream, Stream.Readable);
-
-        TestStream.prototype._read = function (size) {
-
-            this._count++;
-
-            if (this._count > 10) {
-                return;
+                super();
+                this._count = -1;
             }
 
-            if (this._count === 10) {
-                this.push(null);
-                return;
-            }
+            _read() {
 
-            this.push(this._count.toString());
+                this._count++;
+
+                if (this._count > 10) {
+                    return;
+                }
+
+                if (this._count === 10) {
+                    this.push(null);
+                    return;
+                }
+
+                this.push(this._count.toString());
+            }
         };
 
         const range = Ammo.header('bytes=2-4', 10);

--- a/test/index.js
+++ b/test/index.js
@@ -126,4 +126,15 @@ describe('Stream', () => {
         const buffer = await Wreck.read(source.pipe(stream));
         expect(buffer.toString()).to.equal('234');
     });
+
+    it('emits error on internal processing errors', async () => {
+
+        const random = new Buffer(5000);
+        const source = Wreck.toReadableStream(random);
+        const stream = new Ammo.Stream({ from: 1000, to: 4000 });
+
+        stream._range = null;         // Force a processing error
+
+        await expect(Wreck.read(source.pipe(stream))).to.reject(Error);
+    });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -81,6 +81,27 @@ describe('header()', () => {
 
 describe('Stream', () => {
 
+    it('throws on invalid ranges', () => {
+
+        const create = (range) => {
+
+            return () => {
+
+                new Ammo.Stream(range);
+            };
+        };
+
+        expect(create()).to.throw(Error);
+        expect(create(true)).to.throw(Error);
+        expect(create({ from: 'banana', to: [] })).to.throw(Error);
+        expect(create({ from: 0.3 })).to.throw(Error);
+        expect(create({ from: 0.3, to: 10 })).to.throw(Error);
+        expect(create({ from: -4, to: 10 })).to.throw(Error);
+        expect(create({ to: -10 })).to.throw(Error);
+        expect(create({ from: 4, to: 10.4 })).to.throw(Error);
+        expect(create({ from: 4, to: 0 })).to.throw(Error);
+    });
+
     it('returns a subset of a stream', async () => {
 
         const random = new Buffer(5000);


### PR DESCRIPTION
Validates the `range` option, and emits `error` on internal errors.

The prevents `uncaughtException` when a `new Ammo.Stream(null)` is used.