### PR TITLE
Support node v18 and drop node v12

### DIFF
--- a/.github/workflows/ci-module.yml
+++ b/.github/workflows/ci-module.yml
@@ -10,3 +10,5 @@ on:
 jobs:
   test:
     uses: hapijs/.github/.github/workflows/ci-module.yml@master
+    with:
+      min-node-version: 14

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,6 @@
-Copyright (c) 2014-2020, Sideway Inc, and project contributors  
-Copyright (c) 2014, Walmart.  
+Copyright (c) 2014-2022, Project contributors
+Copyright (c) 2014-2020, Sideway Inc
+Copyright (c) 2014, Walmart.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/lib/index.js
+++ b/lib/index.js
@@ -112,12 +112,12 @@ exports.Clip = class extends Stream.Transform {
         if (!(range instanceof internals.Range)) {
             Hoek.assert(typeof range === 'object', 'Expected "range" object');
 
-            const from = range.from || 0;
-            Hoek.assert(typeof from === 'number', '"range.from" must be falsy, or a number');
+            const from = range.from ?? 0;
+            Hoek.assert(typeof from === 'number', '"range.from" must be a number');
             Hoek.assert(from === parseInt(from, 10) && from >= 0, '"range.from" must be a positive integer');
 
-            const to = range.to || 0;
-            Hoek.assert(typeof to === 'number', '"range.to" must be falsy, or a number');
+            const to = range.to ?? 0;
+            Hoek.assert(typeof to === 'number', '"range.to" must be a number');
             Hoek.assert(to === parseInt(to, 10) && to >= 0, '"range.to" must be a positive integer');
 
             Hoek.assert(to >= from, '"range.to" must be greater than or equal to "range.from"');

--- a/package.json
+++ b/package.json
@@ -19,14 +19,15 @@
     ]
   },
   "dependencies": {
-    "@hapi/hoek": "9.x.x"
+    "@hapi/hoek": "^10.0.0"
   },
   "devDependencies": {
-    "@hapi/code": "8.x.x",
+    "@hapi/code": "^9.0.0",
     "@hapi/eslint-plugin": "*",
-    "@hapi/lab": "24.x.x",
-    "@hapi/wreck": "17.x.x",
-    "typescript": "~4.0.2"
+    "@hapi/lab": "^25.0.1",
+    "@hapi/wreck": "^18.0.0",
+    "@types/node": "^17.0.31",
+    "typescript": "~4.6.4"
   },
   "scripts": {
     "test": "lab -a @hapi/code -t 100 -L -Y",

--- a/test/index.js
+++ b/test/index.js
@@ -107,6 +107,16 @@ describe('Stream', () => {
         expect(buffer.toString()).to.equal(random.slice(1000, 4001).toString());
     });
 
+    it('returns a minimal subset of a stream', async () => {
+
+        const random = Buffer.alloc(5000);
+        const source = Wreck.toReadableStream(random);
+        const stream = new Ammo.Clip({ from: null, to: null }); // Defaults to range 0-0
+
+        const buffer = await Wreck.read(source.pipe(stream));
+        expect(buffer.toString()).to.equal(random.slice(0, 1).toString());
+    });
+
     it('processes multiple chunks', async () => {
 
         const TestStream = class extends Stream.Readable {


### PR DESCRIPTION
 - Test on node v14+ and adopt some new syntax.
 - Update to node v18-compatible versions of hapi modules, update typescript.

If this looks good, this will go out as ammo v6.